### PR TITLE
添加coap模块服务器端例程代码

### DIFF
--- a/firmware/app/app/src/application.c
+++ b/firmware/app/app/src/application.c
@@ -146,6 +146,8 @@ void sys_init_thread(void* parameter){
         log_e("File System initialization failed!");
     }
 
+	log_i("Firmware version is %s ", SOFTWARE_VERSION);
+
     extern void contiki_init(void);
     contiki_init();
 

--- a/firmware/app/components/contiki/examples/er-rest-example/er-example-client.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-example-client.c
@@ -65,7 +65,7 @@
 
 /* FIXME: This server address is hard-coded for Cooja and link-local for unconnected border router. */
 //#define SERVER_NODE(ipaddr)   uip_ip6addr(ipaddr, 0xbbbb, 0, 0, 0, 0, 0, 0, 0x100)      /* cooja2 */
-#define SERVER_NODE(ipaddr)   uip_ip6addr(ipaddr, 0xbbbb, 0, 0, 0, 0x4664, 0x1B11, 0xB27B, 0x19ED)
+#define SERVER_NODE(ipaddr)   uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0202, 0x0232, 0x3105, 0x3F52)
 #define LOCAL_PORT      UIP_HTONS(COAP_DEFAULT_PORT + 1)
 #define REMOTE_PORT     UIP_HTONS(COAP_DEFAULT_PORT)
 
@@ -81,7 +81,7 @@ static struct etimer et;
 #define NUMBER_OF_URLS 4
 /* leading and ending slashes only for demo purposes, get cropped automatically when setting the Uri-Path */
 char *service_urls[NUMBER_OF_URLS] =
-{ ".well-known/core", "/monitor", "battery/", "error/in//path" };
+{ ".well-known/core", "test/hello", "battery/", "error/in//path" };
 
 /* This function is will be passed to COAP_BLOCKING_REQUEST() to handle responses. */
 void client_chunk_handler(void *response) {
@@ -93,7 +93,7 @@ void client_chunk_handler(void *response) {
 PROCESS_THREAD(er_example_client, ev, data) {
 
     PROCESS_BEGIN();
-    static  char msg[] = {"[23.0,50.0,123.0,100.0,10.0,0.50]"};
+    static  char msg[] = {"hello"};
     static coap_packet_t request[1]; /* This way the packet can be treated as pointer as usual. */
 
 #ifdef auto_find_server

--- a/firmware/app/components/contiki/examples/er-rest-example/er-example-server.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-example-server.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Erbium (Er) REST Engine example.
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "contiki.h"
+#include "contiki-net.h"
+#include "rest-engine.h"
+
+#if PLATFORM_HAS_BUTTON
+#include "dev/button-sensor.h"
+#endif
+
+#define DEBUG 1
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#define PRINT6ADDR(addr) PRINTF("[%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x]", ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], ((uint8_t *)addr)[4], ((uint8_t *)addr)[5], ((uint8_t *)addr)[6], ((uint8_t *)addr)[7], ((uint8_t *)addr)[8], ((uint8_t *)addr)[9], ((uint8_t *)addr)[10], ((uint8_t *)addr)[11], ((uint8_t *)addr)[12], ((uint8_t *)addr)[13], ((uint8_t *)addr)[14], ((uint8_t *)addr)[15])
+#define PRINTLLADDR(lladdr) PRINTF("[%02x:%02x:%02x:%02x:%02x:%02x]", (lladdr)->addr[0], (lladdr)->addr[1], (lladdr)->addr[2], (lladdr)->addr[3], (lladdr)->addr[4], (lladdr)->addr[5])
+#else
+#define PRINTF(...)
+#define PRINT6ADDR(addr)
+#define PRINTLLADDR(addr)
+#endif
+
+/*
+ * Resources to be activated need to be imported through the extern keyword.
+ * The build system automatically compiles the resources in the corresponding sub-directory.
+ */
+extern resource_t
+  res_hello,
+  res_mirror,
+  res_chunks,
+  res_separate,
+  res_push,
+  res_event,
+  res_sub,
+  res_b1_sep_b2;
+#if PLATFORM_HAS_LEDS
+extern resource_t res_leds, res_toggle;
+#endif
+#if PLATFORM_HAS_LIGHT
+#include "dev/light-sensor.h"
+extern resource_t res_light;
+#endif
+#if PLATFORM_HAS_BATTERY
+#include "dev/battery-sensor.h"
+extern resource_t res_battery;
+#endif
+#if PLATFORM_HAS_TEMPERATURE
+#include "dev/temperature-sensor.h"
+extern resource_t res_temperature;
+#endif
+/*
+extern resource_t res_battery;
+#endif
+#if PLATFORM_HAS_RADIO
+#include "dev/radio-sensor.h"
+extern resource_t res_radio;
+#endif
+#if PLATFORM_HAS_SHT11
+#include "dev/sht11/sht11-sensor.h"
+extern resource_t res_sht11;
+#endif
+*/
+
+PROCESS(er_example_server, "Erbium Example Server");
+//AUTOSTART_PROCESSES(&er_example_server);
+
+PROCESS_THREAD(er_example_server, ev, data)
+{
+  PROCESS_BEGIN();
+
+  PROCESS_PAUSE();
+
+  PRINTF("Starting Erbium Example Server\n");
+
+#ifdef RF_CHANNEL
+  PRINTF("RF channel: %u\n", RF_CHANNEL);
+#endif
+#ifdef IEEE802154_PANID
+  PRINTF("PAN ID: 0x%04X\n", IEEE802154_PANID);
+#endif
+
+  PRINTF("uIP buffer: %u\n", UIP_BUFSIZE);
+  PRINTF("LL header: %u\n", UIP_LLH_LEN);
+  PRINTF("IP+UDP header: %u\n", UIP_IPUDPH_LEN);
+  PRINTF("REST max chunk: %u\n", REST_MAX_CHUNK_SIZE);
+
+  /* Initialize the REST engine. */
+  rest_init_engine();
+
+  /*
+   * Bind the resources to their Uri-Path.
+   * WARNING: Activating twice only means alternate path, not two instances!
+   * All static variables are the same for each URI path.
+   */
+  rest_activate_resource(&res_hello, "test/hello");
+/*  rest_activate_resource(&res_mirror, "debug/mirror"); */
+/*  rest_activate_resource(&res_chunks, "test/chunks"); */
+/*  rest_activate_resource(&res_separate, "test/separate"); */
+  rest_activate_resource(&res_push, "test/push");
+/*  rest_activate_resource(&res_event, "sensors/button"); */
+/*  rest_activate_resource(&res_sub, "test/sub"); */
+/*  rest_activate_resource(&res_b1_sep_b2, "test/b1sepb2"); */
+#if PLATFORM_HAS_LEDS
+/*  rest_activate_resource(&res_leds, "actuators/leds"); */
+  rest_activate_resource(&res_toggle, "actuators/toggle");
+#endif
+#if PLATFORM_HAS_LIGHT
+  rest_activate_resource(&res_light, "sensors/light"); 
+  SENSORS_ACTIVATE(light_sensor);  
+#endif
+#if PLATFORM_HAS_BATTERY
+  rest_activate_resource(&res_battery, "sensors/battery");  
+  SENSORS_ACTIVATE(battery_sensor);  
+#endif
+#if PLATFORM_HAS_TEMPERATURE
+  rest_activate_resource(&res_temperature, "sensors/temperature");  
+  SENSORS_ACTIVATE(temperature_sensor);  
+#endif
+/*
+#if PLATFORM_HAS_RADIO
+  rest_activate_resource(&res_radio, "sensors/radio");  
+  SENSORS_ACTIVATE(radio_sensor);  
+#endif
+#if PLATFORM_HAS_SHT11
+  rest_activate_resource(&res_sht11, "sensors/sht11");  
+  SENSORS_ACTIVATE(sht11_sensor);  
+#endif
+*/
+
+  /* Define application-specific events here. */
+  while(1) {
+    PROCESS_WAIT_EVENT();
+#if PLATFORM_HAS_BUTTON
+    if(ev == sensors_event && data == &button_sensor) {
+      PRINTF("*******BUTTON*******\n");
+
+      /* Call the event_handler for this application-specific event. */
+      res_event.trigger();
+
+      /* Also call the separate response example handler. */
+      res_separate.resume();
+    }
+#endif /* PLATFORM_HAS_BUTTON */
+  }                             /* while (1) */
+
+  PROCESS_END();
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/er-rest-example.h
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-rest-example.h
@@ -31,14 +31,10 @@
 
 #include "contiki.h"
 
-#ifndef ER_EXAMPLE_NAME
-#define ER_EXAMPLE_CLIENT
-#endif
-
-#ifdef ER_EXAMPLE_CLIENT
-PROCESS_NAME(er_example_client);
-#else
+#if COAP_SERVER_ENABLE
 PROCESS_NAME(er_example_server);
-#endif
+#else
+PROCESS_NAME(er_example_client);
+#endif /* COAP_SERVER_ENABLE */
 
 #endif /* _ER_REST_EXAMPLE_H_ */

--- a/firmware/app/components/contiki/examples/er-rest-example/er-rest-example.h
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-rest-example.h
@@ -31,6 +31,14 @@
 
 #include "contiki.h"
 
+#ifndef ER_EXAMPLE_NAME
+#define ER_EXAMPLE_CLIENT
+#endif
+
+#ifdef ER_EXAMPLE_CLIENT
 PROCESS_NAME(er_example_client);
+#else
+PROCESS_NAME(er_example_server);
+#endif
 
 #endif /* _ER_REST_EXAMPLE_H_ */

--- a/firmware/app/components/contiki/examples/er-rest-example/er-rest-example.h
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-rest-example.h
@@ -31,10 +31,7 @@
 
 #include "contiki.h"
 
-#if COAP_SERVER_ENABLE
 PROCESS_NAME(er_example_server);
-#else
 PROCESS_NAME(er_example_client);
-#endif /* COAP_SERVER_ENABLE */
 
 #endif /* _ER_REST_EXAMPLE_H_ */

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-b1-sep-b2.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-b1-sep-b2.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2014, Lars Schmertmann <SmallLars@t-online.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Lars Schmertmann <SmallLars@t-online.de>
+ */
+
+#include <string.h>
+#include "rest-engine.h"
+#include "er-coap-block1.h"
+#include "er-coap-separate.h"
+#include "er-coap-transactions.h"
+
+static void res_post_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+SEPARATE_RESOURCE(res_b1_sep_b2, "title=\"Block1 + Separate + Block2 demo\"", NULL, res_post_handler, NULL, NULL, NULL);
+
+#define MAX_DATA_LEN 256
+
+static uint8_t big_msg[MAX_DATA_LEN];
+static size_t big_msg_len = 0;
+static coap_separate_t request_metadata;
+
+static void
+res_post_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  /* Example allows only one request on time. There are no checks for multiply access !!! */
+  if(*offset == 0) {
+    /* Incoming Data */
+    if(coap_block1_handler(request, response, big_msg, &big_msg_len, MAX_DATA_LEN)) {
+      /* More Blocks will follow. Example waits for
+       * the last block and stores data into big_msg.
+       */
+      return;
+    }
+    /* Last block was received. */
+    coap_separate_accept(request, &request_metadata);
+
+    /* Need Time for calculation now */
+    unsigned i;
+    for(i = 0; i <= 4096; i++) {
+      printf("\r%4u\r", i);
+    }
+    printf("\n");
+
+    /* Send first block */
+    coap_transaction_t *transaction = NULL;
+    if((transaction = coap_new_transaction(request_metadata.mid, &request_metadata.addr, request_metadata.port))) {
+      coap_packet_t resp[1]; /* This way the packet can be treated as pointer as usual. */
+
+      /* Restore the request information for the response. */
+      coap_separate_resume(resp, &request_metadata, CONTENT_2_05);
+
+      /* Set payload and block info */
+      coap_set_payload(resp, big_msg, big_msg_len > request_metadata.block2_size ? request_metadata.block2_size : big_msg_len);
+      if(big_msg_len > request_metadata.block2_size) {
+        coap_set_header_block2(resp, 0, 1, request_metadata.block2_size);
+      }
+
+      /* Warning: No check for serialization error. */
+      transaction->packet_len = coap_serialize_message(resp, transaction->packet);
+      coap_send_transaction(transaction);
+    }
+  } else {
+    /* request for more blocks */
+    if(*offset >= big_msg_len) {
+      coap_set_status_code(response, BAD_OPTION_4_02);
+      coap_set_payload(response, "BlockOutOfScope", 15);
+      return;
+    }
+
+    memcpy(buffer, big_msg + *offset, 32);
+    if(big_msg_len - *offset < preferred_size) {
+      preferred_size = big_msg_len - *offset;
+      *offset = -1;
+    } else {
+      *offset += preferred_size;
+    }
+    coap_set_payload(response, buffer, preferred_size);
+  }
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-battery.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-battery.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include "contiki.h"
+
+#if PLATFORM_HAS_BATTERY
+
+#include <string.h>
+#include "rest-engine.h"
+#include "dev/battery-sensor.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/* A simple getter example. Returns the reading from light sensor with a simple etag */
+RESOURCE(res_battery,
+         "title=\"Battery status\";rt=\"Battery\"",
+         res_get_handler,
+         NULL,
+         NULL,
+         NULL);
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  int battery = battery_sensor.value(0);
+
+  unsigned int accept = -1;
+  REST.get_header_accept(request, &accept);
+
+  if(accept == -1 || accept == REST.type.TEXT_PLAIN) {
+    REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "%d", battery);
+
+    REST.set_response_payload(response, (uint8_t *)buffer, strlen((char *)buffer));
+  } else if(accept == REST.type.APPLICATION_JSON) {
+    REST.set_header_content_type(response, REST.type.APPLICATION_JSON);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "{'battery':%d}", battery);
+
+    REST.set_response_payload(response, buffer, strlen((char *)buffer));
+  } else {
+    REST.set_response_status(response, REST.status.NOT_ACCEPTABLE);
+    const char *msg = "Supporting content-types text/plain and application/json";
+    REST.set_response_payload(response, msg, strlen(msg));
+  }
+}
+#endif /* PLATFORM_HAS_BATTERY */

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-chunks.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-chunks.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include <string.h>
+#include "rest-engine.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/*
+ * For data larger than REST_MAX_CHUNK_SIZE (e.g., when stored in flash) resources must be aware of the buffer limitation
+ * and split their responses by themselves. To transfer the complete resource through a TCP stream or CoAP's blockwise transfer,
+ * the byte offset where to continue is provided to the handler as int32_t pointer.
+ * These chunk-wise resources must set the offset value to its new position or -1 of the end is reached.
+ * (The offset for CoAP's blockwise transfer can go up to 2'147'481'600 = ~2047 M for block size 2048 (reduced to 1024 in observe-03.)
+ */
+RESOURCE(res_chunks,
+         "title=\"Blockwise demo\";rt=\"Data\"",
+         res_get_handler,
+         NULL,
+         NULL,
+         NULL);
+
+#define CHUNKS_TOTAL    2050
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  int32_t strpos = 0;
+
+  /* Check the offset for boundaries of the resource data. */
+  if(*offset >= CHUNKS_TOTAL) {
+    REST.set_response_status(response, REST.status.BAD_OPTION);
+    /* A block error message should not exceed the minimum block size (16). */
+
+    const char *error_msg = "BlockOutOfScope";
+    REST.set_response_payload(response, error_msg, strlen(error_msg));
+    return;
+  }
+
+  /* Generate data until reaching CHUNKS_TOTAL. */
+  while(strpos < preferred_size) {
+    strpos += snprintf((char *)buffer + strpos, preferred_size - strpos + 1, "|%ld|", *offset);
+  }
+
+  /* snprintf() does not adjust return value if truncated by size. */
+  if(strpos > preferred_size) {
+    strpos = preferred_size;
+    /* Truncate if above CHUNKS_TOTAL bytes. */
+  }
+  if(*offset + (int32_t)strpos > CHUNKS_TOTAL) {
+    strpos = CHUNKS_TOTAL - *offset;
+  }
+  REST.set_response_payload(response, buffer, strpos);
+
+  /* IMPORTANT for chunk-wise resources: Signal chunk awareness to REST engine. */
+  *offset += strpos;
+
+  /* Signal end of resource representation. */
+  if(*offset >= CHUNKS_TOTAL) {
+    *offset = -1;
+  }
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-event.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-event.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include <string.h>
+#include "rest-engine.h"
+#include "er-coap.h"
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#define PRINT6ADDR(addr) PRINTF("[%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x]", ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], ((uint8_t *)addr)[4], ((uint8_t *)addr)[5], ((uint8_t *)addr)[6], ((uint8_t *)addr)[7], ((uint8_t *)addr)[8], ((uint8_t *)addr)[9], ((uint8_t *)addr)[10], ((uint8_t *)addr)[11], ((uint8_t *)addr)[12], ((uint8_t *)addr)[13], ((uint8_t *)addr)[14], ((uint8_t *)addr)[15])
+#define PRINTLLADDR(lladdr) PRINTF("[%02x:%02x:%02x:%02x:%02x:%02x]", (lladdr)->addr[0], (lladdr)->addr[1], (lladdr)->addr[2], (lladdr)->addr[3], (lladdr)->addr[4], (lladdr)->addr[5])
+#else
+#define PRINTF(...)
+#define PRINT6ADDR(addr)
+#define PRINTLLADDR(addr)
+#endif
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_event_handler(void);
+
+/*
+ * Example for an event resource.
+ * Additionally takes a period parameter that defines the interval to call [name]_periodic_handler().
+ * A default post_handler takes care of subscriptions and manages a list of subscribers to notify.
+ */
+EVENT_RESOURCE(res_event,
+               "title=\"Event demo\";obs",
+               res_get_handler,
+               NULL,
+               NULL,
+               NULL,
+               res_event_handler);
+
+/*
+ * Use local resource state that is accessed by res_get_handler() and altered by res_event_handler() or PUT or POST.
+ */
+static int32_t event_counter = 0;
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_response_payload(response, buffer, snprintf((char *)buffer, preferred_size, "EVENT %lu", event_counter));
+
+  /* A post_handler that handles subscriptions/observing will be called for periodic resources by the framework. */
+}
+/*
+ * Additionally, res_event_handler must be implemented for each EVENT_RESOURCE.
+ * It is called through <res_name>.trigger(), usually from the server process.
+ */
+static void
+res_event_handler(void)
+{
+  /* Do the update triggered by the event here, e.g., sampling a sensor. */
+  ++event_counter;
+
+  /* Usually a condition is defined under with subscribers are notified, e.g., event was above a threshold. */
+  if(1) {
+    PRINTF("TICK %u for /%s\n", event_counter, res_event.url);
+
+    /* Notify the registered observers which will trigger the res_get_handler to create the response. */
+    REST.notify_subscribers(&res_event);
+  }
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-hello.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-hello.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "rest-engine.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/*
+ * A handler function named [resource name]_handler must be implemented for each RESOURCE.
+ * A buffer for the response payload is provided through the buffer pointer. Simple resources can ignore
+ * preferred_size and offset, but must respect the REST_MAX_CHUNK_SIZE limit for the buffer.
+ * If a smaller block size is requested for CoAP, the REST framework automatically splits the data.
+ */
+RESOURCE(res_hello,
+         "title=\"Hello world: ?len=0..\";rt=\"Text\"",
+         res_get_handler,
+         NULL,
+         NULL,
+         NULL);
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  const char *len = NULL;
+  /* Some data that has the length up to REST_MAX_CHUNK_SIZE. For more, see the chunk resource. */
+  char const *const message = "Hello World! ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxy";
+  int length = 12; /*           |<-------->| */
+
+  /* The query string can be retrieved by rest_get_query() or parsed for its key-value pairs. */
+  if(REST.get_query_variable(request, "len", &len)) {
+    length = atoi(len);
+    if(length < 0) {
+      length = 0;
+    }
+    if(length > REST_MAX_CHUNK_SIZE) {
+      length = REST_MAX_CHUNK_SIZE;
+    }
+    memcpy(buffer, message, length);
+  } else {
+    memcpy(buffer, message, length);
+  } REST.set_header_content_type(response, REST.type.TEXT_PLAIN); /* text/plain is the default, hence this option could be omitted. */
+  REST.set_header_etag(response, (uint8_t *)&length, 1);
+  REST.set_response_payload(response, buffer, length);
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-leds.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-leds.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include "contiki.h"
+
+#if PLATFORM_HAS_LEDS
+
+#include <string.h>
+#include "rest-engine.h"
+#include "dev/leds.h"
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#define PRINT6ADDR(addr) PRINTF("[%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x]", ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], ((uint8_t *)addr)[4], ((uint8_t *)addr)[5], ((uint8_t *)addr)[6], ((uint8_t *)addr)[7], ((uint8_t *)addr)[8], ((uint8_t *)addr)[9], ((uint8_t *)addr)[10], ((uint8_t *)addr)[11], ((uint8_t *)addr)[12], ((uint8_t *)addr)[13], ((uint8_t *)addr)[14], ((uint8_t *)addr)[15])
+#define PRINTLLADDR(lladdr) PRINTF("[%02x:%02x:%02x:%02x:%02x:%02x]", (lladdr)->addr[0], (lladdr)->addr[1], (lladdr)->addr[2], (lladdr)->addr[3], (lladdr)->addr[4], (lladdr)->addr[5])
+#else
+#define PRINTF(...)
+#define PRINT6ADDR(addr)
+#define PRINTLLADDR(addr)
+#endif
+
+static void res_post_put_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/*A simple actuator example, depending on the color query parameter and post variable mode, corresponding led is activated or deactivated*/
+RESOURCE(res_leds,
+         "title=\"LEDs: ?color=r|g|b, POST/PUT mode=on|off\";rt=\"Control\"",
+         NULL,
+         res_post_put_handler,
+         res_post_put_handler,
+         NULL);
+
+static void
+res_post_put_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  size_t len = 0;
+  const char *color = NULL;
+  const char *mode = NULL;
+  uint8_t led = 0;
+  int success = 1;
+
+  if((len = REST.get_query_variable(request, "color", &color))) {
+    PRINTF("color %.*s\n", len, color);
+
+    if(strncmp(color, "r", len) == 0) {
+      led = LEDS_RED;
+    } else if(strncmp(color, "g", len) == 0) {
+      led = LEDS_GREEN;
+    } else if(strncmp(color, "b", len) == 0) {
+      led = LEDS_BLUE;
+    } else {
+      success = 0;
+    }
+  } else {
+    success = 0;
+  } if(success && (len = REST.get_post_variable(request, "mode", &mode))) {
+    PRINTF("mode %s\n", mode);
+
+    if(strncmp(mode, "on", len) == 0) {
+      leds_on(led);
+    } else if(strncmp(mode, "off", len) == 0) {
+      leds_off(led);
+    } else {
+      success = 0;
+    }
+  } else {
+    success = 0;
+  } if(!success) {
+    REST.set_response_status(response, REST.status.BAD_REQUEST);
+  }
+}
+#endif /* PLATFORM_HAS_LEDS */

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-light.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-light.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include "contiki.h"
+
+#if PLATFORM_HAS_LIGHT
+
+#include <string.h>
+#include "rest-engine.h"
+#include "dev/light-sensor.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/* A simple getter example. Returns the reading from light sensor with a simple etag */
+RESOURCE(res_light,
+         "title=\"Photosynthetic and solar light (supports JSON)\";rt=\"LightSensor\"",
+         res_get_handler,
+         NULL,
+         NULL,
+         NULL);
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  uint16_t light_photosynthetic = light_sensor.value(LIGHT_SENSOR_PHOTOSYNTHETIC);
+  uint16_t light_solar = light_sensor.value(LIGHT_SENSOR_TOTAL_SOLAR);
+
+  unsigned int accept = -1;
+  REST.get_header_accept(request, &accept);
+
+  if(accept == -1 || accept == REST.type.TEXT_PLAIN) {
+    REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "%u;%u", light_photosynthetic, light_solar);
+
+    REST.set_response_payload(response, (uint8_t *)buffer, strlen((char *)buffer));
+  } else if(accept == REST.type.APPLICATION_XML) {
+    REST.set_header_content_type(response, REST.type.APPLICATION_XML);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "<light photosynthetic=\"%u\" solar=\"%u\"/>", light_photosynthetic, light_solar);
+
+    REST.set_response_payload(response, buffer, strlen((char *)buffer));
+  } else if(accept == REST.type.APPLICATION_JSON) {
+    REST.set_header_content_type(response, REST.type.APPLICATION_JSON);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "{'light':{'photosynthetic':%u,'solar':%u}}", light_photosynthetic, light_solar);
+
+    REST.set_response_payload(response, buffer, strlen((char *)buffer));
+  } else {
+    REST.set_response_status(response, REST.status.NOT_ACCEPTABLE);
+    const char *msg = "Supporting content-types text/plain, application/xml, and application/json";
+    REST.set_response_payload(response, msg, strlen(msg));
+  }
+}
+#endif /* PLATFORM_HAS_LIGHT */

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-mirror.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-mirror.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include <string.h>
+#include "rest-engine.h"
+#include "er-coap.h"
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#define PRINT6ADDR(addr) PRINTF("[%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x]", ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], ((uint8_t *)addr)[4], ((uint8_t *)addr)[5], ((uint8_t *)addr)[6], ((uint8_t *)addr)[7], ((uint8_t *)addr)[8], ((uint8_t *)addr)[9], ((uint8_t *)addr)[10], ((uint8_t *)addr)[11], ((uint8_t *)addr)[12], ((uint8_t *)addr)[13], ((uint8_t *)addr)[14], ((uint8_t *)addr)[15])
+#define PRINTLLADDR(lladdr) PRINTF("[%02x:%02x:%02x:%02x:%02x:%02x]", (lladdr)->addr[0], (lladdr)->addr[1], (lladdr)->addr[2], (lladdr)->addr[3], (lladdr)->addr[4], (lladdr)->addr[5])
+#else
+#define PRINTF(...)
+#define PRINT6ADDR(addr)
+#define PRINTLLADDR(addr)
+#endif
+
+static void res_any_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/* This resource mirrors the incoming request. It shows how to access the options and how to set them for the response. */
+RESOURCE(res_mirror,
+         "title=\"Returns your decoded message\";rt=\"Debug\"",
+         res_any_handler,
+         res_any_handler,
+         res_any_handler,
+         res_any_handler);
+
+static void
+res_any_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  /* The ETag and Token is copied to the header. */
+  uint8_t opaque[] = { 0x0A, 0xBC, 0xDE };
+
+  /* Strings are not copied, so use static string buffers or strings in .text memory (char *str = "string in .text";). */
+  static char location[] = { '/', 'f', '/', 'a', '?', 'k', '&', 'e', 0 };
+
+  /* No default my be assumed for the Content-Format. (Unsigned -1 means all bits set.) */
+  unsigned int content_format = -1;
+
+  /* The other getters copy the value (or string/array pointer) to the given pointers and return 1 for success or the length of strings/arrays. */
+  uint32_t longint = 0;
+  const char *str = NULL;
+  const uint8_t *bytes = NULL;
+  uint32_t block_num = 0;
+  uint8_t block_more = 0;
+  uint16_t block_size = 0;
+  int len = 0;
+
+  /* Mirror the received header options in the response payload. Unsupported getters (e.g., rest_get_header_observe() with HTTP) will return 0. */
+
+  int strpos = 0;
+  /* snprintf() counts the terminating '\0' to the size parameter.
+   * The additional byte is taken care of by allocating REST_MAX_CHUNK_SIZE+1 bytes in the REST framework.
+   * Add +1 to fill the complete buffer, as the payload does not need a terminating '\0'. */
+  if(REST.get_header_content_type(request, &content_format)) {
+    strpos += snprintf((char *)buffer, REST_MAX_CHUNK_SIZE + 1, "CF %u\n", content_format);
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && (len = REST.get_header_accept(request, &content_format))) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "Ac %u\n", content_format);
+    /* Some getters such as for ETag or Location are omitted, as these options should not appear in a request.
+     * Max-Age might appear in HTTP requests or used for special purposes in CoAP. */
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && REST.get_header_max_age(request, &longint)) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "MA %lu\n", longint);
+    /* For HTTP this is the Length option, for CoAP it is the Size option. */
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && REST.get_header_length(request, &longint)) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "SZ %lu\n", longint);
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && (len = REST.get_header_host(request, &str))) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "UH %.*s\n", len, str);
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && (len = REST.get_url(request, &str))) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "UP %.*s\n", len, str);
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && (len = REST.get_query(request, &str))) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "UQ %.*s\n", len, str);
+    /* Undefined request options for debugging: actions not required for normal RESTful Web service. */
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && (len = coap_get_header_location_path(request, &str))) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "LP %.*s\n", len, str);
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && (len = coap_get_header_location_query(request, &str))) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "LQ %.*s\n", len, str);
+    /* CoAP-specific example: actions not required for normal RESTful Web service. */
+  }
+  coap_packet_t *const coap_pkt = (coap_packet_t *)request;
+
+  if(strpos <= REST_MAX_CHUNK_SIZE && coap_pkt->token_len > 0) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "To 0x");
+    int index = 0;
+    for(index = 0; index < coap_pkt->token_len; ++index) {
+      strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "%02X", coap_pkt->token[index]);
+    }
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "\n");
+  }
+
+  if(strpos <= REST_MAX_CHUNK_SIZE && IS_OPTION(coap_pkt, COAP_OPTION_OBSERVE)) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "Ob %lu\n", coap_pkt->observe);
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && IS_OPTION(coap_pkt, COAP_OPTION_ETAG)) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "ET 0x");
+    int index = 0;
+    for(index = 0; index < coap_pkt->etag_len; ++index) {
+      strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "%02X", coap_pkt->etag[index]);
+    }
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "\n");
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && coap_get_header_block2(request, &block_num, &block_more, &block_size, NULL)) { /* This getter allows NULL pointers to get only a subset of the block parameters. */
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "B2 %lu%s (%u)\n", block_num, block_more ? "+" : "", block_size);
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && coap_get_header_block1(request, &block_num, &block_more, &block_size, NULL)) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "B1 %lu%s (%u)\n", block_num, block_more ? "+" : "", block_size);
+  }
+  if(strpos <= REST_MAX_CHUNK_SIZE && (len = REST.get_request_payload(request, &bytes))) {
+    strpos += snprintf((char *)buffer + strpos, REST_MAX_CHUNK_SIZE - strpos + 1, "%.*s", len, bytes);
+  }
+  if(strpos >= REST_MAX_CHUNK_SIZE) {
+    buffer[REST_MAX_CHUNK_SIZE - 1] = 0xBB; /* '»' to indicate truncation */
+  }
+  REST.set_response_payload(response, buffer, strpos);
+
+  PRINTF("/mirror options received: %s\n", buffer);
+
+  /* Set dummy header options for response. Like getters, some setters are not implemented for HTTP and have no effect. */
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_max_age(response, 17); /* For HTTP, browsers will not re-request the page for 17 seconds. */
+  REST.set_header_etag(response, opaque, 2);
+  REST.set_header_location(response, location); /* Initial slash is omitted by framework */
+  REST.set_header_length(response, strpos); /* For HTTP, browsers will not re-request the page for 10 seconds. CoAP action depends on the client. */
+
+/* CoAP-specific example: actions not required for normal RESTful Web service. */
+  coap_set_header_uri_host(response, "tiki");
+  coap_set_header_observe(response, 10);
+  coap_set_header_proxy_uri(response, "ftp://x");
+  coap_set_header_block2(response, 42, 0, 64); /* The block option might be overwritten by the framework when blockwise transfer is requested. */
+  coap_set_header_block1(response, 23, 0, 16);
+  coap_set_header_accept(response, TEXT_PLAIN);
+  coap_set_header_if_none_match(response);
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-push.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-push.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include <string.h>
+#include "rest-engine.h"
+#include "er-coap.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_periodic_handler(void);
+
+PERIODIC_RESOURCE(res_push,
+                  "title=\"Periodic demo\";obs",
+                  res_get_handler,
+                  NULL,
+                  NULL,
+                  NULL,
+                  5 * CLOCK_SECOND,
+                  res_periodic_handler);
+
+/*
+ * Use local resource state that is accessed by res_get_handler() and altered by res_periodic_handler() or PUT or POST.
+ */
+static int32_t event_counter = 0;
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  /*
+   * For minimal complexity, request query and options should be ignored for GET on observable resources.
+   * Otherwise the requests must be stored with the observer list and passed by REST.notify_subscribers().
+   * This would be a TODO in the corresponding files in contiki/apps/erbium/!
+   */
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+  REST.set_header_max_age(response, res_push.periodic->period / CLOCK_SECOND);
+  REST.set_response_payload(response, buffer, snprintf((char *)buffer, preferred_size, "VERY LONG EVENT %lu", event_counter));
+
+  /* The REST.subscription_handler() will be called for observable resources by the REST framework. */
+}
+/*
+ * Additionally, a handler function named [resource name]_handler must be implemented for each PERIODIC_RESOURCE.
+ * It will be called by the REST manager process with the defined period.
+ */
+static void
+res_periodic_handler()
+{
+  /* Do a periodic task here, e.g., sampling a sensor. */
+  ++event_counter;
+
+  /* Usually a condition is defined under with subscribers are notified, e.g., large enough delta in sensor reading. */
+  if(1) {
+    /* Notify the registered observers which will trigger the res_get_handler to create the response. */
+    REST.notify_subscribers(&res_push);
+  }
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-radio.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-radio.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include "contiki.h"
+
+#if PLATFORM_HAS_RADIO
+
+#include <string.h>
+#include "rest-engine.h"
+#include "dev/radio-sensor.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/* A simple getter example. Returns the reading of the rssi/lqi from radio sensor */
+RESOURCE(res_radio,
+         "title=\"RADIO: ?p=lqi|rssi\";rt=\"RadioSensor\"",
+         res_get_handler,
+         NULL,
+         NULL,
+         NULL);
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  size_t len = 0;
+  const char *p = NULL;
+  uint8_t param = 0;
+  int success = 1;
+
+  unsigned int accept = -1;
+  REST.get_header_accept(request, &accept);
+
+  if((len = REST.get_query_variable(request, "p", &p))) {
+    if(strncmp(p, "lqi", len) == 0) {
+      param = RADIO_SENSOR_LAST_VALUE;
+    } else if(strncmp(p, "rssi", len) == 0) {
+      param = RADIO_SENSOR_LAST_PACKET;
+    } else {
+      success = 0;
+    }
+  } else {
+    success = 0;
+  } if(success) {
+    if(accept == -1 || accept == REST.type.TEXT_PLAIN) {
+      REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+      snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "%d", radio_sensor.value(param));
+
+      REST.set_response_payload(response, (uint8_t *)buffer, strlen((char *)buffer));
+    } else if(accept == REST.type.APPLICATION_JSON) {
+      REST.set_header_content_type(response, REST.type.APPLICATION_JSON);
+
+      if(param == RADIO_SENSOR_LAST_VALUE) {
+        snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "{'lqi':%d}", radio_sensor.value(param));
+      } else if(param == RADIO_SENSOR_LAST_PACKET) {
+        snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "{'rssi':%d}", radio_sensor.value(param));
+      }
+      REST.set_response_payload(response, buffer, strlen((char *)buffer));
+    } else {
+      REST.set_response_status(response, REST.status.NOT_ACCEPTABLE);
+      const char *msg = "Supporting content-types text/plain and application/json";
+      REST.set_response_payload(response, msg, strlen(msg));
+    }
+  } else {
+    REST.set_response_status(response, REST.status.BAD_REQUEST);
+  }
+}
+#endif /* PLATFORM_HAS_RADIO */

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-separate.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-separate.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include <string.h>
+#include "rest-engine.h"
+#include "er-coap-separate.h"
+#include "er-coap-transactions.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_resume_handler(void);
+
+SEPARATE_RESOURCE(res_separate,
+                  "title=\"Separate demo\"",
+                  res_get_handler,
+                  NULL,
+                  NULL,
+                  NULL,
+                  res_resume_handler);
+
+/* A structure to store the information required for the separate handler */
+typedef struct application_separate_store {
+
+  /* Provided by Erbium to store generic request information such as remote address and token. */
+  coap_separate_t request_metadata;
+
+  /* Add fields for addition information to be stored for finalizing, e.g.: */
+  char buffer[16];
+} application_separate_store_t;
+
+#define COAP_MAX_OPEN_SEPARATE   2
+
+static uint8_t separate_active = 0;
+static application_separate_store_t separate_store[COAP_MAX_OPEN_SEPARATE];
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  /*
+   * Example allows only one open separate response.
+   * For multiple, the application must manage the list of stores.
+   */
+  if(separate_active >= COAP_MAX_OPEN_SEPARATE) {
+    coap_separate_reject();
+  } else {
+    ++separate_active;
+
+    /* Take over and skip response by engine. */
+    coap_separate_accept(request, &separate_store->request_metadata);
+    /* Be aware to respect the Block2 option, which is also stored in the coap_separate_t. */
+
+    /*
+     * At the moment, only the minimal information is stored in the store (client address, port, token, MID, type, and Block2).
+     * Extend the store, if the application requires additional information from this handler.
+     * buffer is an example field for custom information.
+     */
+    snprintf(separate_store->buffer, sizeof(separate_store->buffer), "StoredInfo");
+  }
+}
+static void
+res_resume_handler()
+{
+  if(separate_active) {
+    coap_transaction_t *transaction = NULL;
+    if((transaction = coap_new_transaction(separate_store->request_metadata.mid, &separate_store->request_metadata.addr, separate_store->request_metadata.port))) {
+      coap_packet_t response[1]; /* This way the packet can be treated as pointer as usual. */
+
+      /* Restore the request information for the response. */
+      coap_separate_resume(response, &separate_store->request_metadata, REST.status.OK);
+
+      coap_set_payload(response, separate_store->buffer, strlen(separate_store->buffer));
+
+      /*
+       * Be aware to respect the Block2 option, which is also stored in the coap_separate_t.
+       * As it is a critical option, this example resource pretends to handle it for compliance.
+       */
+      coap_set_header_block2(response, separate_store->request_metadata.block2_num, 0, separate_store->request_metadata.block2_size);
+
+      /* Warning: No check for serialization error. */
+      transaction->packet_len = coap_serialize_message(response, transaction->packet);
+      coap_send_transaction(transaction);
+      /* The engine will clear the transaction (right after send for NON, after acked for CON). */
+
+      /* FIXME there could me more! */
+      separate_active = 0;
+    } else {
+      /*
+       * Set timer for retry, send error message, ...
+       * The example simply waits for another button press.
+       */
+    }
+  } /* if (separate_active) */
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-sht11.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-sht11.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2014, Nimbus Centre for Embedded Systems Research, Cork Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      SHT11 Sensor Resource
+ *
+ *      This is a simple GET resource that returns the temperature in Celsius
+ *      and the humidity reading from the SHT11.
+ * \author
+ *      Pablo Corbalan <paul.corbalan@gmail.com>
+ */
+
+#include "contiki.h"
+
+#if PLATFORM_HAS_SHT11
+
+#include <string.h>
+#include "rest-engine.h"
+#include "dev/sht11/sht11-sensor.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/* Get Method Example. Returns the reading from temperature and humidity sensors. */
+RESOURCE(res_sht11,
+         "title=\"Temperature and Humidity\";rt=\"Sht11\"",
+         res_get_handler,
+         NULL,
+         NULL,
+         NULL);
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  /* Temperature in Celsius (t in 14 bits resolution at 3 Volts)
+   * T = -39.60 + 0.01*t
+   */
+  uint16_t temperature = ((sht11_sensor.value(SHT11_SENSOR_TEMP) / 10) - 396) / 10;
+  /* Relative Humidity in percent (h in 12 bits resolution)
+   * RH = -4 + 0.0405*h - 2.8e-6*(h*h)
+   */
+  uint16_t rh = sht11_sensor.value(SHT11_SENSOR_HUMIDITY);
+
+  unsigned int accept = -1;
+  REST.get_header_accept(request, &accept);
+
+  if(accept == -1 || accept == REST.type.TEXT_PLAIN) {
+    REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "%u;%u", temperature, rh);
+
+    REST.set_response_payload(response, (uint8_t *)buffer, strlen((char *)buffer));
+  } else if(accept == REST.type.APPLICATION_XML) {
+    REST.set_header_content_type(response, REST.type.APPLICATION_XML);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "<Temperature =\"%u\" Humidity=\"%u\"/>", temperature, rh);
+
+    REST.set_response_payload(response, buffer, strlen((char *)buffer));
+  } else if(accept == REST.type.APPLICATION_JSON) {
+    REST.set_header_content_type(response, REST.type.APPLICATION_JSON);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "{'Sht11':{'Temperature':%u,'Humidity':%u}}", temperature, rh);
+
+    REST.set_response_payload(response, buffer, strlen((char *)buffer));
+  } else {
+    REST.set_response_status(response, REST.status.NOT_ACCEPTABLE);
+    const char *msg = "Supporting content-types text/plain, application/xml, and application/json";
+    REST.set_response_payload(response, msg, strlen(msg));
+  }
+}
+#endif /* PLATFORM_HAS_SHT11 */

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-sub.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-sub.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include <string.h>
+#include "rest-engine.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/*
+ * Example for a resource that also handles all its sub-resources.
+ * Use REST.get_url() to multiplex the handling of the request depending on the Uri-Path.
+ */
+PARENT_RESOURCE(res_sub,
+                "title=\"Sub-resource demo\"",
+                res_get_handler,
+                NULL,
+                NULL,
+                NULL);
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+
+  const char *uri_path = NULL;
+  int len = REST.get_url(request, &uri_path);
+  int base_len = strlen(res_sub.url);
+
+  if(len == base_len) {
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "Request any sub-resource of /%s", res_sub.url);
+  } else {
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, ".%.*s", len - base_len, uri_path + base_len);
+  } REST.set_response_payload(response, buffer, strlen((char *)buffer));
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-temperature.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-temperature.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example of an observable "on-change" temperature resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ * \author
+ *      Cristiano De Alti <cristiano_dealti@hotmail.com>
+ */
+
+#include "contiki.h"
+
+#if PLATFORM_HAS_TEMPERATURE
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include "rest-engine.h"
+#include "dev/temperature-sensor.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static void res_periodic_handler(void);
+
+#define MAX_AGE      60
+#define INTERVAL_MIN 5
+#define INTERVAL_MAX (MAX_AGE - 1)
+#define CHANGE       1 
+
+static int32_t interval_counter = INTERVAL_MIN;
+static int temperature_old = INT_MIN;
+
+PERIODIC_RESOURCE(res_temperature,
+         "title=\"Temperature\";rt=\"Temperature\";obs",
+         res_get_handler,
+         NULL,
+         NULL,
+         NULL,
+         CLOCK_SECOND,
+         res_periodic_handler);
+
+static void
+res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  /*
+   * For minimal complexity, request query and options should be ignored for GET on observable resources.
+   * Otherwise the requests must be stored with the observer list and passed by REST.notify_subscribers().
+   * This would be a TODO in the corresponding files in contiki/apps/erbium/!
+   */
+
+  int temperature = temperature_sensor.value(0);
+
+  unsigned int accept = -1;
+  REST.get_header_accept(request, &accept);
+
+  if(accept == -1 || accept == REST.type.TEXT_PLAIN) {
+    REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "%d", temperature);
+
+    REST.set_response_payload(response, (uint8_t *)buffer, strlen((char *)buffer));
+  } else if(accept == REST.type.APPLICATION_JSON) {
+    REST.set_header_content_type(response, REST.type.APPLICATION_JSON);
+    snprintf((char *)buffer, REST_MAX_CHUNK_SIZE, "{'temperature':%d}", temperature);
+
+    REST.set_response_payload(response, buffer, strlen((char *)buffer));
+  } else {
+    REST.set_response_status(response, REST.status.NOT_ACCEPTABLE);
+    const char *msg = "Supporting content-types text/plain and application/json";
+    REST.set_response_payload(response, msg, strlen(msg));
+  }
+
+  REST.set_header_max_age(response, MAX_AGE);
+
+  /* The REST.subscription_handler() will be called for observable resources by the REST framework. */
+}
+
+/*
+ * Additionally, a handler function named [resource name]_handler must be implemented for each PERIODIC_RESOURCE.
+ * It will be called by the REST manager process with the defined period.
+ */
+static void
+res_periodic_handler()
+{
+  int temperature = temperature_sensor.value(0);
+
+  ++interval_counter;
+
+  if((abs(temperature - temperature_old) >= CHANGE && interval_counter >= INTERVAL_MIN) || 
+     interval_counter >= INTERVAL_MAX) {
+     interval_counter = 0;
+     temperature_old = temperature;
+    /* Notify the registered observers which will trigger the res_get_handler to create the response. */
+    REST.notify_subscribers(&res_temperature);
+  }
+}
+#endif /* PLATFORM_HAS_TEMPERATURE */

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-toggle.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-toggle.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example resource
+ * \author
+ *      Matthias Kovatsch <kovatsch@inf.ethz.ch>
+ */
+
+#include "contiki.h"
+
+#if PLATFORM_HAS_LEDS
+
+#include <string.h>
+#include "contiki.h"
+#include "rest-engine.h"
+#include "dev/leds.h"
+
+static void res_post_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+/* A simple actuator example. Toggles the red led */
+RESOURCE(res_toggle,
+         "title=\"Red LED\";rt=\"Control\"",
+         NULL,
+         res_post_handler,
+         NULL,
+         NULL);
+
+static void
+res_post_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
+{
+  leds_toggle(LEDS_RED);
+}
+#endif /* PLATFORM_HAS_LEDS */

--- a/firmware/app/components/contiki/examples/ipv6/6lbr/cetic-6lbr-client.c
+++ b/firmware/app/components/contiki/examples/ipv6/6lbr/cetic-6lbr-client.c
@@ -45,6 +45,10 @@
 #define DEBUG 0
 #include "net/ip/uip-debug.h"
 /*---------------------------------------------------------------------------*/
+#ifndef CETIC_6LBR_CLIENT_VERSION
+#define CETIC_6LBR_CLIENT_VERSION                      "0.0.1"
+#endif
+
 #ifndef CETIC_6LBR_NODE_INFO_PORT
 #define CETIC_6LBR_NODE_INFO_PORT 3000
 #endif
@@ -179,6 +183,7 @@ PROCESS_THREAD(cetic_6lbr_client_process, ev, data)
   PROCESS_BEGIN();
 
   printf("6LBR Client Process\r\n");
+  printf("version : %s \r\n", CETIC_6LBR_CLIENT_VERSION);
 
   memset(&dest_addr, 0, sizeof(uip_ipaddr_t));
 

--- a/firmware/app/components/contiki/examples/ipv6/6lbr/cetic-6lbr-client.c
+++ b/firmware/app/components/contiki/examples/ipv6/6lbr/cetic-6lbr-client.c
@@ -45,10 +45,6 @@
 #define DEBUG 0
 #include "net/ip/uip-debug.h"
 /*---------------------------------------------------------------------------*/
-#ifndef CETIC_6LBR_CLIENT_VERSION
-#define CETIC_6LBR_CLIENT_VERSION                      "0.0.1"
-#endif
-
 #ifndef CETIC_6LBR_NODE_INFO_PORT
 #define CETIC_6LBR_NODE_INFO_PORT 3000
 #endif
@@ -183,7 +179,6 @@ PROCESS_THREAD(cetic_6lbr_client_process, ev, data)
   PROCESS_BEGIN();
 
   printf("6LBR Client Process\r\n");
-  printf("version : %s \r\n", CETIC_6LBR_CLIENT_VERSION);
 
   memset(&dest_addr, 0, sizeof(uip_ipaddr_t));
 

--- a/firmware/app/components/contiki/port/contiki-main.c
+++ b/firmware/app/components/contiki/port/contiki-main.c
@@ -165,13 +165,15 @@ void contiki_init(void) {
     autostart_start(autostart_processes);
 #endif /* RAW_RADIO_TEST */
 
+#if COAP_ENABLE
 	/* start coap */
 #include <examples/er-rest-example/er-rest-example.h>
-#ifdef ER_EXAMPLE_CLIENT
-	process_start(&er_example_client, NULL);
-#else
+#if COAP_SERVER_ENABLE
 	process_start(&er_example_server, NULL);
-#endif
+#else
+	process_start(&er_example_client, NULL);
+#endif /* COAP_SERVER_ENABLE */
+#endif /* COAP_ENABLE */
 
     rt_thread_t thread = rt_thread_create("contiki_main", contiki_main_thread_entry, NULL, 2048, RT_THREAD_PRIORITY_MAX - 2, 9);
     if (thread) {

--- a/firmware/app/components/contiki/port/contiki-main.c
+++ b/firmware/app/components/contiki/port/contiki-main.c
@@ -40,6 +40,7 @@
 #include <serial-line-arch.h>
 #include <apps/shell/serial-shell.h>
 #include <apps/shell/shell.h>
+#include <examples/er-rest-example/er-rest-example.h>
 
 #include <stdio.h>
 #include <stdbool.h>
@@ -165,15 +166,14 @@ void contiki_init(void) {
     autostart_start(autostart_processes);
 #endif /* RAW_RADIO_TEST */
 
-#if COAP_ENABLE
 	/* start coap */
-#include <examples/er-rest-example/er-rest-example.h>
 #if COAP_SERVER_ENABLE
 	process_start(&er_example_server, NULL);
-#else
-	process_start(&er_example_client, NULL);
 #endif /* COAP_SERVER_ENABLE */
-#endif /* COAP_ENABLE */
+
+#if COAP_CLIENT_ENABLE
+	process_start(&er_example_client, NULL);
+#endif /* COAP_CLIENT_ENABLE */
 
     rt_thread_t thread = rt_thread_create("contiki_main", contiki_main_thread_entry, NULL, 2048, RT_THREAD_PRIORITY_MAX - 2, 9);
     if (thread) {

--- a/firmware/app/components/contiki/port/contiki-main.c
+++ b/firmware/app/components/contiki/port/contiki-main.c
@@ -165,9 +165,13 @@ void contiki_init(void) {
     autostart_start(autostart_processes);
 #endif /* RAW_RADIO_TEST */
 
-    /* start coap */
-//#include <examples/er-rest-example/er-rest-example.h>
-//    process_start(&er_example_client, NULL);
+	/* start coap */
+#include <examples/er-rest-example/er-rest-example.h>
+#ifdef ER_EXAMPLE_CLIENT
+	process_start(&er_example_client, NULL);
+#else
+	process_start(&er_example_server, NULL);
+#endif
 
     rt_thread_t thread = rt_thread_create("contiki_main", contiki_main_thread_entry, NULL, 2048, RT_THREAD_PRIORITY_MAX - 2, 9);
     if (thread) {

--- a/firmware/app/components/contiki/port/project-conf.h
+++ b/firmware/app/components/contiki/port/project-conf.h
@@ -78,7 +78,7 @@
 #define CONTIKI_SLIP_RAIDO                    0
 #if CONTIKI_SLIP_RAIDO
     #define QUEUEBUF_CONF_NUM                 4
-    #define UIP_CONF_BUFFER_SIZE              140
+    #define UIP_CONF_BUFFER_SIZE              512
     #undef UIP_CONF_ROUTER
     #define UIP_CONF_ROUTER                   0
     #define CMD_CONF_OUTPUT                   slip_radio_cmd_output
@@ -105,7 +105,7 @@
 /*---------------------------------------------------------------------------*/
 /* CoAP */
 #define COAP_ENABLE                           1
-#define COAP_SERVER_ENABLE                    0
+#define COAP_SERVER_ENABLE                    1
 #if COAP_ENABLE
     #define REST                              REGISTERED_ENGINE_ERBIUM
 #endif /* COAP_ENABLE */

--- a/firmware/app/components/contiki/port/project-conf.h
+++ b/firmware/app/components/contiki/port/project-conf.h
@@ -104,11 +104,11 @@
 #endif /* CONTIKI_SLIP_RAIDO */
 /*---------------------------------------------------------------------------*/
 /* CoAP */
-#define COAP_ENABLE                           1
 #define COAP_SERVER_ENABLE                    1
-#if COAP_ENABLE
-    #define REST                              REGISTERED_ENGINE_ERBIUM
-#endif /* COAP_ENABLE */
+#define COAP_CLIENT_ENABLE                    0
+#if (COAP_SERVER_ENABLE || COAP_CLIENT_ENABLE)
+	#define REST                              REGISTERED_ENGINE_ERBIUM
+#endif
 
 #endif /* PROJECT_CONF_H_ */
 /*---------------------------------------------------------------------------*/

--- a/firmware/app/rtconfig.h
+++ b/firmware/app/rtconfig.h
@@ -47,7 +47,11 @@
 /* RT_USING_INTERRUPT_INFO is not set */
 #define RT_USING_CONSOLE
 #define RT_CONSOLEBUF_SIZE 1024
+#if CONTIKI_SLIP_RAIDO
+#define RT_CONSOLE_DEVICE_NAME "uart2"
+#else
 #define RT_CONSOLE_DEVICE_NAME "uart1"
+#endif
 /* RT_USING_MODULE is not set */
 #define ARCH_ARM
 #define ARCH_ARM_CORTEX_M


### PR DESCRIPTION
1.【修改】 修改er-rest-example.h文件，根据project-conf.h文件的配置选择初始化客户端还是服务器；
2.【修改】 修改contiki-main.c文件，根据配置文件选择初始化coap的客户端还是服务器；
3.【修改】 rtconfig.h文件，当编译边界路由固件时，将日志重定向到串口2；

Signed-off-by: xidongxu <xi_dongxu@126.com>