### PR TITLE
 添加获取cpu使用率与获取cpu温度的coap资源文件

### DIFF
--- a/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.c
@@ -1,7 +1,6 @@
 /*
- * This file is part of the ART-6LoWPAN Radio Library.
+ * This file is part of the ART-6LoWPAN.
  *
- * Copyright (c) 2017, Armink, <armink.ztl@gmail.com>
  * Copyright (c) 2017, xidongxu, <xi_dongxu@126.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.c
@@ -1,0 +1,83 @@
+/*
+ * er-cpu-temperate.c
+ *
+ *  Created on: 2017年12月6日
+ *      Author: xdx
+ */
+
+#include "stm32f4xx.h"
+#include "rtthread.h"
+
+/**
+ * 获取CPU温度ADC硬件初始化
+ *
+ */
+void get_cpu_temperature_init(void) {
+	ADC_CommonInitTypeDef ADC_CommonInitStructure;
+	ADC_InitTypeDef ADC_InitStructure;
+
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
+	RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC1, ENABLE);
+	RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC1, DISABLE);
+	ADC_TempSensorVrefintCmd(ENABLE);
+
+	ADC_CommonInitStructure.ADC_Mode = ADC_Mode_Independent;
+	ADC_CommonInitStructure.ADC_TwoSamplingDelay = ADC_TwoSamplingDelay_20Cycles;
+	ADC_CommonInitStructure.ADC_DMAAccessMode = ADC_DMAAccessMode_Disabled;
+	ADC_CommonInitStructure.ADC_Prescaler = ADC_Prescaler_Div4;
+	ADC_CommonInit(&ADC_CommonInitStructure);
+
+	ADC_InitStructure.ADC_Resolution = ADC_Resolution_12b;
+	ADC_InitStructure.ADC_ScanConvMode = DISABLE;
+	ADC_InitStructure.ADC_ContinuousConvMode = DISABLE;
+	ADC_InitStructure.ADC_ExternalTrigConvEdge = ADC_ExternalTrigConvEdge_None;
+	ADC_InitStructure.ADC_ExternalTrigConv = ADC_ExternalTrigConv_T1_CC1;
+	ADC_InitStructure.ADC_DataAlign = ADC_DataAlign_Right;
+	ADC_InitStructure.ADC_NbrOfConversion = 1;
+	ADC_Init(ADC1, &ADC_InitStructure);
+	ADC_RegularChannelConfig(ADC1, ADC_Channel_16, 1, ADC_SampleTime_112Cycles);
+	ADC_Cmd(ADC1, ENABLE);
+}
+
+/**
+ * 获取ADC值函数
+ *
+ * @param ch 通道
+ * @return ADC数值
+ */
+uint16_t get_adc(u8 ch) {
+	ADC_RegularChannelConfig(ADC1, ch, 1, ADC_SampleTime_112Cycles );
+	ADC_SoftwareStartConv(ADC1);
+	while(!ADC_GetFlagStatus(ADC1, ADC_FLAG_EOC ));
+	return ADC_GetConversionValue(ADC1);
+}
+
+/**
+ * 获取CPU温度函数
+ *
+ * @return CPU温度值
+ */
+uint32_t get_cpu_temperature(void) {
+	uint32_t adc[10] = { 0 }, adc_max = 0, adc_min = 0;
+	uint32_t adc_value = 0, adc_sum = 0;
+	double temperature = 0.0;
+	for (uint8_t t = 0; t < 10; t++) {
+		adc[t] = get_adc(ADC_Channel_16);
+		adc_sum = adc_sum + adc[t];
+		rt_thread_delay(rt_tick_from_millisecond(5));
+	}
+	adc_max = adc[0];
+	adc_min = adc[0];
+	for (uint8_t t = 1; t < 10; t++) {
+		if (adc_max < adc[t]) {
+			adc_max = adc[t];
+		}
+		if (adc_min > adc[t]) {
+			adc_min = adc[t];
+		}
+	}
+	adc_value = ((adc_sum - adc_max - adc_min) / 8);
+	temperature = (float) adc_value * (3.3 / 4096);
+	temperature = (temperature - 0.76) / 0.0025 + 25;
+	return (uint32_t)(temperature);
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.c
@@ -1,8 +1,30 @@
 /*
- * er-cpu-temperate.c
+ * This file is part of the ART-6LoWPAN Radio Library.
  *
- *  Created on: 2017年12月6日
- *      Author: xdx
+ * Copyright (c) 2017, Armink, <armink.ztl@gmail.com>
+ * Copyright (c) 2017, xidongxu, <xi_dongxu@126.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Function: Obtaining hardware initialization of CPU internal temperature sensor data.
+ * Created on: 2017-12-08
  */
 
 #include "stm32f4xx.h"
@@ -13,30 +35,30 @@
  *
  */
 void get_cpu_temperature_init(void) {
-	ADC_CommonInitTypeDef ADC_CommonInitStructure;
-	ADC_InitTypeDef ADC_InitStructure;
+    ADC_CommonInitTypeDef ADC_CommonInitStructure;
+    ADC_InitTypeDef ADC_InitStructure;
 
-	RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
-	RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC1, ENABLE);
-	RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC1, DISABLE);
-	ADC_TempSensorVrefintCmd(ENABLE);
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC1, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_ADC1, DISABLE);
+    ADC_TempSensorVrefintCmd(ENABLE);
 
-	ADC_CommonInitStructure.ADC_Mode = ADC_Mode_Independent;
-	ADC_CommonInitStructure.ADC_TwoSamplingDelay = ADC_TwoSamplingDelay_20Cycles;
-	ADC_CommonInitStructure.ADC_DMAAccessMode = ADC_DMAAccessMode_Disabled;
-	ADC_CommonInitStructure.ADC_Prescaler = ADC_Prescaler_Div4;
-	ADC_CommonInit(&ADC_CommonInitStructure);
+    ADC_CommonInitStructure.ADC_Mode = ADC_Mode_Independent;
+    ADC_CommonInitStructure.ADC_TwoSamplingDelay = ADC_TwoSamplingDelay_20Cycles;
+    ADC_CommonInitStructure.ADC_DMAAccessMode = ADC_DMAAccessMode_Disabled;
+    ADC_CommonInitStructure.ADC_Prescaler = ADC_Prescaler_Div4;
+    ADC_CommonInit(&ADC_CommonInitStructure);
 
-	ADC_InitStructure.ADC_Resolution = ADC_Resolution_12b;
-	ADC_InitStructure.ADC_ScanConvMode = DISABLE;
-	ADC_InitStructure.ADC_ContinuousConvMode = DISABLE;
-	ADC_InitStructure.ADC_ExternalTrigConvEdge = ADC_ExternalTrigConvEdge_None;
-	ADC_InitStructure.ADC_ExternalTrigConv = ADC_ExternalTrigConv_T1_CC1;
-	ADC_InitStructure.ADC_DataAlign = ADC_DataAlign_Right;
-	ADC_InitStructure.ADC_NbrOfConversion = 1;
-	ADC_Init(ADC1, &ADC_InitStructure);
-	ADC_RegularChannelConfig(ADC1, ADC_Channel_16, 1, ADC_SampleTime_112Cycles);
-	ADC_Cmd(ADC1, ENABLE);
+    ADC_InitStructure.ADC_Resolution = ADC_Resolution_12b;
+    ADC_InitStructure.ADC_ScanConvMode = DISABLE;
+    ADC_InitStructure.ADC_ContinuousConvMode = DISABLE;
+    ADC_InitStructure.ADC_ExternalTrigConvEdge = ADC_ExternalTrigConvEdge_None;
+    ADC_InitStructure.ADC_ExternalTrigConv = ADC_ExternalTrigConv_T1_CC1;
+    ADC_InitStructure.ADC_DataAlign = ADC_DataAlign_Right;
+    ADC_InitStructure.ADC_NbrOfConversion = 1;
+    ADC_Init(ADC1, &ADC_InitStructure);
+    ADC_RegularChannelConfig(ADC1, ADC_Channel_16, 1, ADC_SampleTime_112Cycles);
+    ADC_Cmd(ADC1, ENABLE);
 }
 
 /**
@@ -46,10 +68,10 @@ void get_cpu_temperature_init(void) {
  * @return ADC数值
  */
 uint16_t get_adc(u8 ch) {
-	ADC_RegularChannelConfig(ADC1, ch, 1, ADC_SampleTime_112Cycles );
-	ADC_SoftwareStartConv(ADC1);
-	while(!ADC_GetFlagStatus(ADC1, ADC_FLAG_EOC ));
-	return ADC_GetConversionValue(ADC1);
+    ADC_RegularChannelConfig(ADC1, ch, 1, ADC_SampleTime_112Cycles );
+    ADC_SoftwareStartConv(ADC1);
+    while(!ADC_GetFlagStatus(ADC1, ADC_FLAG_EOC ));
+    return ADC_GetConversionValue(ADC1);
 }
 
 /**
@@ -58,26 +80,26 @@ uint16_t get_adc(u8 ch) {
  * @return CPU温度值
  */
 uint32_t get_cpu_temperature(void) {
-	uint32_t adc[10] = { 0 }, adc_max = 0, adc_min = 0;
-	uint32_t adc_value = 0, adc_sum = 0;
-	double temperature = 0.0;
-	for (uint8_t t = 0; t < 10; t++) {
-		adc[t] = get_adc(ADC_Channel_16);
-		adc_sum = adc_sum + adc[t];
-		rt_thread_delay(rt_tick_from_millisecond(5));
-	}
-	adc_max = adc[0];
-	adc_min = adc[0];
-	for (uint8_t t = 1; t < 10; t++) {
-		if (adc_max < adc[t]) {
-			adc_max = adc[t];
-		}
-		if (adc_min > adc[t]) {
-			adc_min = adc[t];
-		}
-	}
-	adc_value = ((adc_sum - adc_max - adc_min) / 8);
-	temperature = (float) adc_value * (3.3 / 4096);
-	temperature = (temperature - 0.76) / 0.0025 + 25;
-	return (uint32_t)(temperature);
+    uint32_t adc[10] = { 0 }, adc_max = 0, adc_min = 0;
+    uint32_t adc_value = 0, adc_sum = 0;
+    double temperature = 0.0;
+    for (uint8_t t = 0; t < 10; t++) {
+        adc[t] = get_adc(ADC_Channel_16);
+        adc_sum = adc_sum + adc[t];
+        rt_thread_delay(rt_tick_from_millisecond(5));
+    }
+    adc_max = adc[0];
+    adc_min = adc[0];
+    for (uint8_t t = 1; t < 10; t++) {
+        if (adc_max < adc[t]) {
+            adc_max = adc[t];
+        }
+        if (adc_min > adc[t]) {
+            adc_min = adc[t];
+        }
+    }
+    adc_value = ((adc_sum - adc_max - adc_min) / 8);
+    temperature = (float) adc_value * (3.3 / 4096);
+    temperature = (temperature - 0.76) / 0.0025 + 25;
+    return (uint32_t)(temperature);
 }

--- a/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.h
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.h
@@ -1,8 +1,30 @@
 /*
- * er-cpu-temperature.h
+ * This file is part of the ART-6LoWPAN Radio Library.
  *
- *  Created on: 2017Äê12ÔÂ6ÈÕ
- *      Author: xdx
+ * Copyright (c) 2017, Armink, <armink.ztl@gmail.com>
+ * Copyright (c) 2017, xidongxu, <xi_dongxu@126.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Function: Obtaining hardware initialization of CPU internal temperature sensor data.
+ * Created on: 2017-12-08
  */
 
 #ifndef _ER_CPU_TEMPERATURE_H_

--- a/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.h
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.h
@@ -1,7 +1,6 @@
 /*
- * This file is part of the ART-6LoWPAN Radio Library.
+ * This file is part of the ART-6LoWPAN.
  *
- * Copyright (c) 2017, Armink, <armink.ztl@gmail.com>
  * Copyright (c) 2017, xidongxu, <xi_dongxu@126.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.h
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-cpu-temperature.h
@@ -1,0 +1,14 @@
+/*
+ * er-cpu-temperature.h
+ *
+ *  Created on: 2017Äê12ÔÂ6ÈÕ
+ *      Author: xdx
+ */
+
+#ifndef _ER_CPU_TEMPERATURE_H_
+#define _ER_CPU_TEMPERATURE_H_
+
+void get_cpu_temperature_init(void);
+uint32_t get_cpu_temperature(void);
+
+#endif /* _ER_CPU_TEMPERATURE_H_ */

--- a/firmware/app/components/contiki/examples/er-rest-example/er-example-server.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/er-example-server.c
@@ -65,6 +65,8 @@
  */
 extern resource_t
   res_hello,
+  res_cpu_usage,
+  res_cpu_temperature,
   res_mirror,
   res_chunks,
   res_separate,
@@ -132,10 +134,12 @@ PROCESS_THREAD(er_example_server, ev, data)
    * All static variables are the same for each URI path.
    */
   rest_activate_resource(&res_hello, "test/hello");
+  rest_activate_resource(&res_cpu_usage, "test/cpu_usage");
+  rest_activate_resource(&res_cpu_temperature, "test/cpu_temperature");
 /*  rest_activate_resource(&res_mirror, "debug/mirror"); */
 /*  rest_activate_resource(&res_chunks, "test/chunks"); */
 /*  rest_activate_resource(&res_separate, "test/separate"); */
-  rest_activate_resource(&res_push, "test/push");
+/*  rest_activate_resource(&res_push, "test/push"); */
 /*  rest_activate_resource(&res_event, "sensors/button"); */
 /*  rest_activate_resource(&res_sub, "test/sub"); */
 /*  rest_activate_resource(&res_b1_sep_b2, "test/b1sepb2"); */

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-temperature.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-temperature.c
@@ -1,7 +1,6 @@
 /*
- * This file is part of the ART-6LoWPAN Radio Library.
+ * This file is part of the ART-6LoWPAN.
  *
- * Copyright (c) 2017, Armink, <armink.ztl@gmail.com>
  * Copyright (c) 2017, xidongxu, <xi_dongxu@126.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-temperature.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-temperature.c
@@ -1,32 +1,30 @@
 /*
- * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
- * All rights reserved.
+ * This file is part of the ART-6LoWPAN Radio Library.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of the Institute nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ * Copyright (c) 2017, Armink, <armink.ztl@gmail.com>
+ * Copyright (c) 2017, xidongxu, <xi_dongxu@126.com>
  *
- * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
  *
- * This file is part of the Contiki operating system.
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Function: Example of get the cpu inside temperature resource.
+ * Created on: 2017-12-08
  */
 
 /**
@@ -45,25 +43,25 @@
 static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
 
 RESOURCE(res_cpu_temperature,
-		"title=\"CPU-temperature\";rt=\"CPU-temperature\";obs",
-		res_get_handler,
-		NULL,
-		NULL,
-		NULL);
+        "title=\"CPU-temperature\";rt=\"CPU-temperature\";obs",
+        res_get_handler,
+        NULL,
+        NULL,
+        NULL);
 
 static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset) {
-	uint8_t length = 0;
-	char temperature[10] = { 0 }, temperature_major[5] = { 0 };
-	static uint8_t inited = 0;
-	if (inited == 0) {
-		get_cpu_temperature_init();
-		inited = 1;
-	}
+    uint8_t length = 0;
+    char temperature[10] = { 0 }, temperature_major[5] = { 0 };
+    static uint8_t inited = 0;
+    if (inited == 0) {
+        get_cpu_temperature_init();
+        inited = 1;
+    }
     snprintf(temperature_major, sizeof(temperature_major), "%d", get_cpu_temperature());
-	strncat(temperature, temperature_major, sizeof(temperature_major));
-	memcpy(buffer, temperature, sizeof(temperature));
-	length = strlen((char *) buffer);
-	REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
-	REST.set_header_etag(response, (uint8_t *) &length, 1);
-	REST.set_response_payload(response, (uint8_t *) buffer, length);
+    strncat(temperature, temperature_major, sizeof(temperature_major));
+    memcpy(buffer, temperature, sizeof(temperature));
+    length = strlen((char *) buffer);
+    REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+    REST.set_header_etag(response, (uint8_t *) &length, 1);
+    REST.set_response_payload(response, (uint8_t *) buffer, length);
 }

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-temperature.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-temperature.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example of get the cpu inside temperature resource
+ */
+
+#include "contiki.h"
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include "rest-engine.h"
+#include "../er-cpu-temperature.h"
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+
+RESOURCE(res_cpu_temperature,
+		"title=\"CPU-temperature\";rt=\"CPU-temperature\";obs",
+		res_get_handler,
+		NULL,
+		NULL,
+		NULL);
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset) {
+	uint8_t length = 0;
+	char temperature[10] = { 0 }, temperature_major[5] = { 0 };
+	static uint8_t inited = 0;
+	if (inited == 0) {
+		get_cpu_temperature_init();
+		inited = 1;
+	}
+    snprintf(temperature_major, sizeof(temperature_major), "%d", get_cpu_temperature());
+	strncat(temperature, temperature_major, sizeof(temperature_major));
+	memcpy(buffer, temperature, sizeof(temperature));
+	length = strlen((char *) buffer);
+	REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+	REST.set_header_etag(response, (uint8_t *) &length, 1);
+	REST.set_response_payload(response, (uint8_t *) buffer, length);
+}

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-usage.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-usage.c
@@ -1,32 +1,30 @@
 /*
- * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
- * All rights reserved.
+ * This file is part of the ART-6LoWPAN Radio Library.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of the Institute nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ * Copyright (c) 2017, Armink, <armink.ztl@gmail.com>
+ * Copyright (c) 2017, xidongxu, <xi_dongxu@126.com>
  *
- * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
  *
- * This file is part of the Contiki operating system.
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Function: Example of get the cpu usage resource.
+ * Created on: 2017-12-08
  */
 
 /**
@@ -54,17 +52,17 @@ RESOURCE(res_cpu_usage,
          NULL);
 
 static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset) {
-	uint8_t length = 0;
-	char usage[10] = { 0 }, usage_major[5] = { 0 }, usage_minor[5] = { 0 };
-	cpu_usage_get(&cpu_usage_major, &cpu_usage_minor);
-	snprintf(usage_major, sizeof(usage_major), "%d", cpu_usage_major);
-	snprintf(usage_minor, sizeof(usage_minor), "%d", cpu_usage_minor);
-	strncat(usage, usage_major, sizeof(usage_major));
-	strncat(usage, ".", strlen("."));
-	strncat(usage, usage_minor, sizeof(usage_minor));
-	memcpy(buffer, usage, sizeof(usage));
-	length = strlen((char *) buffer);
-	REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
-	REST.set_header_etag(response, (uint8_t *) &length, 1);
-	REST.set_response_payload(response, (uint8_t *) buffer, length);
+    uint8_t length = 0;
+    char usage[10] = { 0 }, usage_major[5] = { 0 }, usage_minor[5] = { 0 };
+    cpu_usage_get(&cpu_usage_major, &cpu_usage_minor);
+    snprintf(usage_major, sizeof(usage_major), "%d", cpu_usage_major);
+    snprintf(usage_minor, sizeof(usage_minor), "%d", cpu_usage_minor);
+    strncat(usage, usage_major, sizeof(usage_major));
+    strncat(usage, ".", strlen("."));
+    strncat(usage, usage_minor, sizeof(usage_minor));
+    memcpy(buffer, usage, sizeof(usage));
+    length = strlen((char *) buffer);
+    REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+    REST.set_header_etag(response, (uint8_t *) &length, 1);
+    REST.set_response_payload(response, (uint8_t *) buffer, length);
 }

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-usage.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-usage.c
@@ -1,7 +1,6 @@
 /*
- * This file is part of the ART-6LoWPAN Radio Library.
+ * This file is part of the ART-6LoWPAN.
  *
- * Copyright (c) 2017, Armink, <armink.ztl@gmail.com>
  * Copyright (c) 2017, xidongxu, <xi_dongxu@126.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-usage.c
+++ b/firmware/app/components/contiki/examples/er-rest-example/resources/res-cpu-usage.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Example of get the cpu usage resource
+ */
+
+#include "contiki.h"
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include "rest-engine.h"
+#include "rtthread.h"
+#include <cpuusage.h>
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
+static uint8_t cpu_usage_major, cpu_usage_minor;
+
+RESOURCE(res_cpu_usage,
+         "title=\"CPU-usage\";rt=\"CPU-usage\";obs",
+         res_get_handler,
+         NULL,
+         NULL,
+         NULL);
+
+static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset) {
+	uint8_t length = 0;
+	char usage[10] = { 0 }, usage_major[5] = { 0 }, usage_minor[5] = { 0 };
+	cpu_usage_get(&cpu_usage_major, &cpu_usage_minor);
+	snprintf(usage_major, sizeof(usage_major), "%d", cpu_usage_major);
+	snprintf(usage_minor, sizeof(usage_minor), "%d", cpu_usage_minor);
+	strncat(usage, usage_major, sizeof(usage_major));
+	strncat(usage, ".", strlen("."));
+	strncat(usage, usage_minor, sizeof(usage_minor));
+	memcpy(buffer, usage, sizeof(usage));
+	length = strlen((char *) buffer);
+	REST.set_header_content_type(response, REST.type.TEXT_PLAIN);
+	REST.set_header_etag(response, (uint8_t *) &length, 1);
+	REST.set_response_payload(response, (uint8_t *) buffer, length);
+}


### PR DESCRIPTION
 - 1.【添加】 添加获取cpu使用率与获取cpu温度的coap资源文件；
 - 2.【修改】 修改coap服务器例程，开启获取CPU温度与使用率的资源；
 - 3.【添加】 添加获取cpu温度的驱动文件； 

 - Signed-off-by: xidongxu <xi_dongxu@126.com>